### PR TITLE
Perf: change u64 to u32

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -441,12 +441,12 @@ impl cosmic::Application for AppModel {
 
             // TODO: refactor all this
             Message::TimerTick => {
-                self.timer.time = self.stopwatch.elapsed().as_millis() as u64;
+                self.timer.time = self.stopwatch.elapsed().as_millis() as u32;
             }
             Message::SpacePressed => {
                 self.space_pressed = true;
                 if self.timer.status == Status::Running {
-                    self.timer.time = self.stopwatch.elapsed().as_millis() as u64;
+                    self.timer.time = self.stopwatch.elapsed().as_millis() as u32;
                     let solve = Solve::new(self.timer.time, &self.current_scramble);
                     self.timer.status = Status::Stopped;
                     self.record.add_solve(solve);

--- a/src/record.rs
+++ b/src/record.rs
@@ -39,13 +39,13 @@ impl Cube {
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Solve {
-    pub time: u64,
+    pub time: u32,
     pub scramble: Vec<String>,
     pub _dnf: bool,
     pub _plus_two: bool,
 }
 impl Solve {
-    pub fn new(time: u64, scramble: &Vec<String>) -> Solve {
+    pub fn new(time: u32, scramble: &Vec<String>) -> Solve {
         Self {
             time,
             scramble: scramble.clone(),
@@ -63,9 +63,9 @@ pub struct Record {
     pub cube: Cube,
     pub solves: Vec<Solve>,
     pub best_solve: Option<Solve>,
-    pub ao5: Option<u64>,
-    pub ao12: Option<u64>,
-    pub ao100: Option<u64>,
+    pub ao5: Option<u32>,
+    pub ao12: Option<u32>,
+    pub ao100: Option<u32>,
 }
 impl Record {
     pub fn default() -> Record {
@@ -88,7 +88,7 @@ impl Record {
     }
 }
 
-fn calc_average(solves: &Vec<Solve>, ao: usize) -> Option<u64> {
+fn calc_average(solves: &Vec<Solve>, ao: usize) -> Option<u32> {
     if solves.len() >= ao {
         let last_n: &[Solve] = &solves[0..ao];
         let mut sum = 0;
@@ -104,7 +104,7 @@ fn calc_average(solves: &Vec<Solve>, ao: usize) -> Option<u64> {
             sum += solve.time;
         }
         sum = sum - high - low;
-        Some(sum / (ao as u64 - 2))
+        Some(sum / (ao as u32 - 2))
     } else {
         None
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,7 +10,7 @@ pub enum Status {
 
 #[derive(Debug)]
 pub struct Timer {
-    pub time: u64,
+    pub time: u32,
     pub status: Status,
 }
 
@@ -33,8 +33,8 @@ impl Timer {
     }
 }
 
-pub fn format_from_ms(time: u64) -> String {
-    let duration = Duration::from_millis(time);
+pub fn format_from_ms(time: u32) -> String {
+    let duration = Duration::from_millis(time.into());
     let minutes = duration.as_millis() / 60_000;
     let seconds = (duration.as_millis() % 60_000) / 1_000;
     let millis = (duration.as_millis() % 1_000) / 10;


### PR DESCRIPTION
Yeah, it saves 3.8MB for each 1,000,000 solves stored

*“Brushing bits” (in direct translation to English) is a popular expression among senior developers in my country (like [@akitaonrails](https://www.youtube.com/@Akitando/videos)), which means, among other things, “worrying about low-level details,” such as excessive and/or unnecessary optimizations.*